### PR TITLE
better handling of "./" in 'go doc ./foo'

### DIFF
--- a/default.go
+++ b/default.go
@@ -4,11 +4,13 @@
 
 package main
 
-import "os"
-import "fmt"
-import "strings"
-import "io/ioutil"
-import "path"
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
 
 func handleDefault(t *tokenizer) {
 	if tok, old := t.Next(); old {

--- a/doc.go
+++ b/doc.go
@@ -4,18 +4,21 @@
 
 package main
 
-import "os"
-import "fmt"
-import "strings"
-import "io/ioutil"
-import "path"
-import "path/filepath"
-import "unicode"
-import "unicode/utf8"
-import "go/doc"
-import "go/build"
-import "go/token"
-import "go/parser"
+import (
+	"fmt"
+	"go/build"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
 
 var args []string
 var matchCase = false
@@ -186,6 +189,19 @@ func suggestPackages(tok string) (cnt int) {
 
 // Expand GOROOT and GOPATH with respect to some dirPath.
 func makePaths(dirPath string) (paths []string) {
+	if strings.HasPrefix(dirPath, ".") {
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err)
+		}
+		dirPath = filepath.Join(cwd, dirPath[1:])
+		for _, dir := range filepath.SplitList(build.Default.GOPATH) {
+			if dir != "" && strings.HasPrefix(cwd, dir) {
+				paths = append(paths, dirPath)
+			}
+		}
+		return
+	}
 	// TODO(jtsai): Can dirPath be an absolute path?
 	for _, dir := range filepath.SplitList(build.Default.GOPATH) {
 		if dir != "" {

--- a/main.go
+++ b/main.go
@@ -19,11 +19,13 @@
 // any characters in COMP_LINE that lies beyond COMP_POINT.
 package main
 
-import "os"
-import "fmt"
-import "path"
-import "strings"
-import "strconv"
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+)
 
 const cmd = "go"
 


### PR DESCRIPTION
This CL handles somewhat better the ./ case.
Instead of displaying:

```
 $> go doc ./g
 ./go ./github.com ./golang.org [...]
```

It will propose the packages beginning with a `g` in the current
directory, if that current directory is under `$GOPATH`:

```
 $> ls
 gopkg mypkg urpkg

 $> go doc ./g
 gopkg gopkg/
```
